### PR TITLE
[Fix] change tooltip to label

### DIFF
--- a/lua/virtuality/module.lua
+++ b/lua/virtuality/module.lua
@@ -35,7 +35,13 @@ local function retrieve_inlay_hints(bufnr, lsp)
 				-- without this check, we'd also get parameter names annotated at EOL, which is not very readable.
 				if hint.kind == 1 and lines_annotated[hint.position.line] ~= true then
 					local position = hint.position
-					local tooltip = hint.tooltip
+					local tooltip
+
+					if type(hint.label) == "table" then
+						tooltip = hint.label[2].value
+					else
+						tooltip = hint.label
+					end
 
 					vim.api.nvim_buf_set_extmark(bufnr, M.namespace, position.line, position.character, {
 						hl_group = "VirtualityInlayHint",

--- a/lua/virtuality/module.lua
+++ b/lua/virtuality/module.lua
@@ -38,7 +38,7 @@ local function retrieve_inlay_hints(bufnr, lsp)
 					local tooltip
 
 					if type(hint.label) == "table" then
-						tooltip = ":" .. hint.label[2].value
+						tooltip = ": " .. hint.label[2].value
 					else
 						tooltip = hint.label
 					end

--- a/lua/virtuality/module.lua
+++ b/lua/virtuality/module.lua
@@ -38,7 +38,7 @@ local function retrieve_inlay_hints(bufnr, lsp)
 					local tooltip
 
 					if type(hint.label) == "table" then
-						tooltip = hint.label[2].value
+						tooltip = ":" .. hint.label[2].value
 					else
 						tooltip = hint.label
 					end


### PR DESCRIPTION
hint has no tooltip, now was label.
When var was a struct in rust, label will return a table.
if hint.label is a table, it will was struct under this line.
hint.label = {
	{ value = ":" },
	{
		value = type_annotation,
		location = {
			url = path_to_type_file,
			range = {
				start = {
					line = type_start_line,
					character = type_start_character,
				},
				end = {
					line = type_start_line,
					character = type_start_character,
				},
			},
		},
	},
	{ value = ''},
}